### PR TITLE
fix host name parsing

### DIFF
--- a/check_riak_ring.py
+++ b/check_riak_ring.py
@@ -121,7 +121,7 @@ def parse_ownership(val):
         if '{' not in k:
             continue
         host, ct = k.split('{')[1].split(',')
-        host = host.split('@')[1]
+        host = host.split('@')[1].strip("'")
         ret[host] = ct
     return ret
 


### PR DESCRIPTION
parse_ownership() was keeping a trailing single quote character for the host name which would cause a <urlopen error [Errno -2] Name or service not known> error.

This fix removes any trailing (or leading) single quotes from the host name when parsing ownership info.
